### PR TITLE
Add new DoH server to the list

### DIFF
--- a/doh-domains.txt
+++ b/doh-domains.txt
@@ -138,6 +138,7 @@ fi.doh.dns.snopyta.org
 free.bravedns.com
 freedns.controld.com
 freedom.mydns.network
+httpdns-push.heytapmobile.com
 hydra.plan9-ns1.com
 i.233py.com
 ibksturm.synology.me

--- a/doh-ipv4.txt
+++ b/doh-ipv4.txt
@@ -178,6 +178,7 @@
 104.21.49.234       # free.bravedns.com
 172.67.195.148      # free.bravedns.com
 76.76.2.11          # freedns.controld.com
+129.227.195.61      # httpdns-push.heytapmobile.com
 173.199.126.35      # hydra.plan9-ns1.com
 213.196.191.96      # ibksturm.synology.me
 168.138.243.216     # ibuki.cgnat.net


### PR DESCRIPTION
Add httpdns-push.heytapmobile.com / 129.227.195.61 to the list.
This was identified from proxy logs at many networks we manage.

Signed-off-by: Nishant Sharma <nishant@hopbox.in>