### PR TITLE
Add new AdGuard domain.

### DIFF
--- a/doh-domains.txt
+++ b/doh-domains.txt
@@ -33,6 +33,7 @@ dns-nyc.aaflalo.me
 dns-unfiltered.adguard.com
 dns-weblock.wevpn.com
 dns.aa.net.uk
+dns.adguard-dns.com
 dns.adguard.com
 dns.alidns.com
 dns.api.globus.org
@@ -197,6 +198,7 @@ edns.233py.com
 ee-tll.doh.sb
 eropa.dnscepat.id
 eu1.dns.lavate.ch
+family.adguard-dns.com
 family.canadianshield.cira.ca
 family.cloudflare-dns.com
 firefox.dns.nextdns.io


### PR DESCRIPTION
It resolves to the same ip address used by the the regular `adguard.com` domain variant.

Based on https://adguard-dns.io/kb/general/dns-providers