### PR TITLE
add doh.archuser.org domain

### DIFF
--- a/doh-domains.txt
+++ b/doh-domains.txt
@@ -513,6 +513,7 @@ doh.aaaab3n.moe
 doh.apad.pro
 doh.applied-privacy.net
 doh.appliedprivacy.net
+doh.archuser.org
 doh.asia.dnswarden.com
 doh.azoris.ovh
 doh.beauty


### PR DESCRIPTION
From https://pubhole.archuser.org:

66.228.61.140
2600:3c02::f03c:94ff:fe86:115d
https://doh.archuser.org/dns-query
tls://doh.archuser.org