### PR TITLE
added dooh.cloudflare-dns.com

### DIFF
--- a/doh-domains_overall.txt
+++ b/doh-domains_overall.txt
@@ -1334,3 +1334,4 @@ zero.dns0.eu
 zougloub.eu
 zrh1-ns01.monzoon.net
 zxcvb.pp.ua
+dooh.cloudflare-dns.com


### PR DESCRIPTION
this doh domain is a default in waterfox browser and was not included