### PR TITLE
Remove ipoac.nl

### DIFF
--- a/doh-domains_overall.txt
+++ b/doh-domains_overall.txt
@@ -1310,7 +1310,6 @@ ines.zfn.uni-bremen.de
 inpssh.online
 internetsehat.bebasid.com
 iow-dns.bitdefender.net
-ipoac.nl
 iris.woozeno.eu
 irre.li
 isb01.dnscry.pt


### PR DESCRIPTION
I haven't hosted a DoH service for some time now and am not planning on doing it again

Please remove it.

```
$ dig example.com @ipoac.nl +https
;; communications error to 2a02:a464:cfa5::1#443: failure
;; communications error to 2a02:a464:cfa5::1#443: failure
;; communications error to 2a02:a464:cfa5::1#443: failure
;; communications error to 84.82.15.107#443: failure

; <<>> DiG 9.20.5-1-Debian <<>> example.com @ipoac.nl +https
;; global options: +cmd
;; no servers could be reached
```

```
$ curl --head https://ipoac.nl/dns-query
HTTP/2 410
...
```

Thanks