### PR TITLE
Exclude private IPv4 and IPv6 addresses

### DIFF
--- a/doh-ipv4.txt
+++ b/doh-ipv4.txt
@@ -2328,9 +2328,6 @@
 192.119.93.224      # dns.reckoningslug.name
 192.121.170.151     # bru01.dnscry.pt
 192.145.47.80       # dns.bermeitinger.eu
-192.168.1.3         # dns.trust404.win
-192.168.1.19        # adguard.blogssl.com
-192.168.1.164       # minilla.store
 192.227.158.134     # resolve2.r9x.cc
 192.248.190.14      # adguard.ruby.ci
 192.252.220.34      # secure.avastdns.com


### PR DESCRIPTION
Including them breaks LAN connections.

The commit below is just an example (since the bugs module is unavailable) and not exhaustive.

Please, adjust the script to never include private ranges. These are:
- 10.0.0.0/8
- 172.16.0.0/12
- 192.168.0.0/16
- fe80::/10

Additionally, the localhost addresses should be excluded, too:
- 127.0.0.1
- ::1